### PR TITLE
evaluation metric logging 세팅

### DIFF
--- a/baseline/arguments.py
+++ b/baseline/arguments.py
@@ -77,7 +77,7 @@ class DataTrainingArguments:
     )
     num_clusters: int = field(default=64, metadata={"help": "Define how many clusters to use for faiss."})
     top_k_retrieval: int = field(
-        default=10,
+        default=100,
         metadata={"help": "Define how many top-k passages to retrieve based on similarity."},
     )
     use_faiss: bool = field(default=False, metadata={"help": "Whether to build with faiss"})

--- a/baseline/inference.py
+++ b/baseline/inference.py
@@ -40,6 +40,7 @@ def main():
 
     # dataset_name을 test_path로 바꿔줍니다.
     data_args.dataset_name = conf.others.test_path
+    data_args.top_k_retrieval = conf.dataset.top_k_retrieval
 
     training_args.do_train = True
 

--- a/baseline/inference.sh
+++ b/baseline/inference.sh
@@ -1,0 +1,4 @@
+python inference.py \
+--output_dir ./outputs/klue_roberta_large_test_dataset \
+--model_name_or_path ./outputs/klue_roberta_large_train_dataset \
+--do_predict

--- a/baseline/train.sh
+++ b/baseline/train.sh
@@ -1,0 +1,4 @@
+python3 train.py \
+--output_dir ./outputs/koelectra-base-v3-finetuned-korquad_train_dataset \
+--do_train \
+--do_eval

--- a/baseline/trainer_qa.py
+++ b/baseline/trainer_qa.py
@@ -33,7 +33,7 @@ class QuestionAnsweringTrainer(Trainer):
         self.eval_examples = eval_examples
         self.post_process_function = post_process_function
 
-    def evaluate(self, eval_dataset=None, eval_examples=None, ignore_keys=None):
+    def evaluate(self, eval_dataset=None, eval_examples=None, ignore_keys=None, metric_key_prefix: str = "eval"):
         eval_dataset = self.eval_dataset if eval_dataset is None else eval_dataset
         eval_dataloader = self.get_eval_dataloader(eval_dataset)
         eval_examples = self.eval_examples if eval_examples is None else eval_examples
@@ -62,6 +62,11 @@ class QuestionAnsweringTrainer(Trainer):
         if self.post_process_function is not None and self.compute_metrics is not None:
             eval_preds = self.post_process_function(eval_examples, eval_dataset, output.predictions, self.args)
             metrics = self.compute_metrics(eval_preds)
+
+            # Prefix all keys with metric_key_prefix + "_"
+            for key in list(metrics.keys()):
+                if not key.startswith(f"{metric_key_prefix}_"):
+                    metrics[f"{metric_key_prefix}_{key}"] = metrics.pop(key)
 
             self.log(metrics)
         else:


### PR DESCRIPTION
## ⚠️ Problem Statement

현재 베이스라인 코드에 2가지 문제점이 있음
1. validation dataset에 대한 metric score인 `eval/exact_match` & `eval/f1`이 `train/exact_match` & `train/f1`으로 **잘못 logging되고 있음**
2. `eval_loss`가 제대로 **logging되고 있지 않음**

## 🔧 Methodology

1. `evaluate()` 함수 내에 **`eval_` prefix로 조정**하여 `train/`이 아닌 `eval/`로 나오도록 설정하기
2. validation dataset의 preprocessing에 start_index와 end_index를 추가로 지정해주고 loss 계산을 위한 label을 지정해서 `eval_loss`도 tracking될 수 있도록 설정하기


## 🚧 TODO LIST

- [x] evaluation metric prefix 추가
- [x] `eval_loss` tracking하도록 설정

## ⚗️ Experiment Setup & Results

<!-- 실험(적용) 과정과 결과 -->

- eval prefix 적용 전
<img width="839" alt="image" src="https://user-images.githubusercontent.com/54230911/210229511-4ef70744-cb13-4f9e-97a1-a7496f634932.png">

- eval prefix 적용 후
<img width="940" alt="image" src="https://user-images.githubusercontent.com/54230911/210229610-a05a1cd1-fc08-429b-b440-a0aedf82f463.png">

## 🔀 Conclusion

- `eval/exact_match`와 `eval/f1`을 표시하고, `eval_loss`를 tracking하여 logging해도 근본적으로 **validation dataset의 개수가 너무 적어 (240개) 평가 점수를 신뢰하기 어려운 문제**가 있음.
- 하지만, validation dataset의 개수를 늘리면 **더 적은 데이터로 학습해야 한다는 문제점**이 있음.
- 따라서, **Extractive MRC 태스크에 맞는 KLUE MRC 데이터셋**과 유사한 목적과 방식으로 만들어진 **KorQuAD와 같은 데이터셋을 현재 데이터 구조에 맞게 전처리한 후 학습 데이터에 추가**하여 평가 데이터셋의 개수를 늘리면 **평가 점수를 신뢰할 수 있을 것**이라 판단됨.

## 🧩 Related Works

- Transformers Question Answering repo에서 [commit log](https://github.com/huggingface/transformers/commits/main?after=375801d5e65457d2ef86e6b269703c5f9ad67252+69&branch=main&path%5B%5D=examples&path%5B%5D=pytorch&path%5B%5D=question-answering&qualified_name=refs%2Fheads%2Fmain)를 살펴보던 중 [eval prefix 변경 commit](https://github.com/huggingface/transformers/commit/e363e1d936e5bfa03e8ddcaa47348c16d42bc6ac)을 찾아 참고하였음. Transformers에서는 test data로 `predict()` 함수에도 변경해주었지만 우리 task에서는 test data에 대한 정답이 없으므로 `evaluate()` 함수만 변경하였음

## 📄 Related Issue

close #9 
