### PR TITLE
retriever 성능 평가 & BM25 적용

### DIFF
--- a/baseline/arguments.py
+++ b/baseline/arguments.py
@@ -81,3 +81,6 @@ class DataTrainingArguments:
         metadata={"help": "Define how many top-k passages to retrieve based on similarity."},
     )
     use_faiss: bool = field(default=False, metadata={"help": "Whether to build with faiss"})
+    bm25: bool = field(
+        default=True, metadata={"help": "Whether to use BM25"}
+    )

--- a/baseline/arguments.py
+++ b/baseline/arguments.py
@@ -81,6 +81,4 @@ class DataTrainingArguments:
         metadata={"help": "Define how many top-k passages to retrieve based on similarity."},
     )
     use_faiss: bool = field(default=False, metadata={"help": "Whether to build with faiss"})
-    bm25: bool = field(
-        default=True, metadata={"help": "Whether to use BM25"}
-    )
+    bm25: bool = field(default=True, metadata={"help": "Whether to use BM25"})

--- a/baseline/inference.py
+++ b/baseline/inference.py
@@ -14,7 +14,7 @@ import numpy as np
 from arguments import DataTrainingArguments, ModelArguments
 from datasets import Dataset, DatasetDict, Features, Sequence, Value, load_from_disk, load_metric
 from omegaconf import OmegaConf
-from retrieval import SparseRetrieval, BM25
+from retrieval import BM25, SparseRetrieval
 from trainer_qa import QuestionAnsweringTrainer
 from transformers import (
     AutoConfig,

--- a/baseline/inference.py
+++ b/baseline/inference.py
@@ -14,7 +14,7 @@ import numpy as np
 from arguments import DataTrainingArguments, ModelArguments
 from datasets import Dataset, DatasetDict, Features, Sequence, Value, load_from_disk, load_metric
 from omegaconf import OmegaConf
-from retrieval import SparseRetrieval
+from retrieval import SparseRetrieval, BM25
 from trainer_qa import QuestionAnsweringTrainer
 from transformers import (
     AutoConfig,
@@ -40,8 +40,14 @@ def main():
 
     # dataset_name을 test_path로 바꿔줍니다.
     data_args.dataset_name = conf.others.test_path
+    data_args.top_k_retrieval = conf.dataset.top_k_retrieval
 
     training_args.do_train = True
+    print("#" * 30)
+    print("model_args: ", model_args)
+    print("data_args: ", data_args)
+    # print("training_args: ", training_args)
+    print("#" * 30)
 
     print(f"model is from {model_args.model_name_or_path}")
     print(f"data is from {data_args.dataset_name}")
@@ -101,7 +107,20 @@ def run_sparse_retrieval(
 ) -> DatasetDict:
 
     # Query에 맞는 Passage들을 Retrieval 합니다.
-    retriever = SparseRetrieval(tokenize_fn=tokenize_fn, data_path=data_path, context_path=context_path)
+    # BM25 사용
+    if data_args.bm25:
+        retriever = BM25(
+            tokenize_fn=tokenize_fn,
+            data_path=data_path,
+            context_path=context_path,
+        )
+    # TF-IDF 사용
+    else:
+        retriever = SparseRetrieval(
+            tokenize_fn=tokenize_fn,
+            data_path=data_path,
+            context_path=context_path,
+        )
     retriever.get_sparse_embedding()
 
     if data_args.use_faiss:

--- a/baseline/retrieval.py
+++ b/baseline/retrieval.py
@@ -394,7 +394,7 @@ def main(args):
     else:
         with timer("bulk query by exhaustive search"):
             df = retriever.retrieve(full_ds, topk=args.topk)
-            # df["correct"] = df["original_context"] == df["context"]
+
             # original_context : ground_truth context / context : retrieve한 context
             df["correct"] = [original_context in context for original_context, context in zip(df["original_context"], df["context"])]
             print(

--- a/baseline/retrieval.py
+++ b/baseline/retrieval.py
@@ -393,8 +393,10 @@ def main(args):
 
     else:
         with timer("bulk query by exhaustive search"):
-            df = retriever.retrieve(full_ds)
-            df["correct"] = df["original_context"] == df["context"]
+            df = retriever.retrieve(full_ds, topk=args.topk)
+            # df["correct"] = df["original_context"] == df["context"]
+            # original_context : ground_truth context / context : retrieve한 context
+            df["correct"] = [original_context in context for original_context, context in zip(df["original_context"], df["context"])]
             print(
                 "correct retrieval result by exhaustive search",
                 df["correct"].sum() / len(df),
@@ -417,6 +419,7 @@ if __name__ == "__main__":
     parser.add_argument("--data_path", default="../data", type=str, help="")
     parser.add_argument("--context_path", default="wikipedia_documents.json", type=str, help="")
     parser.add_argument("--use_faiss", default=False, type=bool, help="")
+    parser.add_argument("--topk", default=40, type=int, help="retrieve 할 문서 개수(topk) 설정")
 
     args = parser.parse_args()
     print(args)

--- a/baseline/retrieval.py
+++ b/baseline/retrieval.py
@@ -7,6 +7,7 @@ import pickle
 import time
 from contextlib import contextmanager
 
+from rank_bm25 import BM25Okapi
 import faiss
 import numpy as np
 import pandas as pd
@@ -184,6 +185,7 @@ class SparseRetrieval:
                     "question": example["question"],
                     "id": example["id"],
                     # Retrieve한 Passage의 id, context를 반환합니다.
+                    "context_id": doc_indices[idx],
                     "context": " ".join([self.contexts[pid] for pid in doc_indices[idx]]),
                 }
                 if "context" in example.keys() and "answers" in example.keys():
@@ -350,6 +352,108 @@ class SparseRetrieval:
         return D.tolist(), I.tolist()
 
 
+class BM25:
+    def __init__(self, tokenize_fn, data_path: Optional[str] = "../data", context_path: Optional[str] = "wikipedia_documents.json"):
+        self.data_path = data_path
+        with open(os.path.join(data_path, context_path), "r", encoding="utf-8") as f:
+            wiki = json.load(f)
+
+        self.contexts = list(dict.fromkeys([v["text"] for v in wiki.values()]))  # set 은 매번 순서가 바뀌므로
+        print(f"Lengths of unique contexts : {len(self.contexts)}")
+        self.ids = list(range(len(self.contexts)))
+
+        self.tokenize_fn = tokenize_fn
+        self.bm25 = None
+
+    def get_sparse_embedding(self):
+        with timer("bm25 building"):
+            self.bm25 = BM25Okapi(self.contexts, tokenizer=self.tokenize_fn)
+
+    def retrieve(
+        self, query_or_dataset: Union[str, Dataset], topk: Optional[int] = 1
+    ) -> Union[Tuple[List, List], pd.DataFrame]:
+
+        """
+        Arguments:
+            query_or_dataset (Union[str, Dataset]):
+                str이나 Dataset으로 이루어진 Query를 받습니다.
+                str 형태인 하나의 query만 받으면 `get_relevant_doc`을 통해 유사도를 구합니다.
+                Dataset 형태는 query를 포함한 HF.Dataset을 받습니다.
+                이 경우 `get_relevant_doc_bulk`를 통해 유사도를 구합니다.
+            topk (Optional[int], optional): Defaults to 1.
+                상위 몇 개의 passage를 사용할 것인지 지정합니다.
+
+        Returns:
+            1개의 Query를 받는 경우  -> Tuple(List, List)
+            다수의 Query를 받는 경우 -> pd.DataFrame: [description]
+
+        Note:
+            다수의 Query를 받는 경우,
+                Ground Truth가 있는 Query (train/valid) -> 기존 Ground Truth Passage를 같이 반환합니다.
+                Ground Truth가 없는 Query (test) -> Retrieval한 Passage만 반환합니다.
+        """
+
+        if isinstance(query_or_dataset, str):
+            doc_scores, doc_indices = self.get_relevant_doc(query_or_dataset, k=topk)
+            print("[Search query]\n", query_or_dataset, "\n")
+
+            for i in range(topk):
+                print(f"Top-{i+1} passage with score {doc_scores[i]:4f}")
+                print(self.contexts[doc_indices[i]])
+
+            return (doc_scores, [self.contexts[doc_indices[i]] for i in range(topk)])
+
+        elif isinstance(query_or_dataset, Dataset):
+
+            # Retrieve한 Passage를 pd.DataFrame으로 반환합니다.
+            total = []
+            with timer("query exhaustive search"):
+                doc_scores, doc_indices = self.get_relevant_doc_bulk(query_or_dataset["question"], k=topk)
+            for idx, example in enumerate(tqdm(query_or_dataset, desc="BM25 Sparse retrieval: ")):
+                tmp = {
+                    # Query와 해당 id를 반환합니다.
+                    "question": example["question"],
+                    "id": example["id"],
+                    # Retrieve한 Passage의 id, context를 반환합니다.
+                    "context_id": doc_indices[idx],
+                    "context": " ".join([self.contexts[pid] for pid in doc_indices[idx]]),
+                }
+                if "context" in example.keys() and "answers" in example.keys():
+                    # validation 데이터를 사용하면 ground_truth context와 answer도 반환합니다.
+                    tmp["original_context"] = example["context"]
+                    tmp["answers"] = example["answers"]
+                total.append(tmp)
+
+            cqas = pd.DataFrame(total)
+            return cqas
+
+    def get_relevant_doc(self, query: str, k: Optional[int] = 1) -> Tuple[List, List]:
+        with timer("transform"):
+            tokenized_query = self.tokenize_fn(query)
+
+        with timer("exhaustive search"):
+            result = self.bm25.get_scores(tokenized_query)
+        sorted_result = np.argsort(result)[::-1]
+        doc_score = result[sorted_result].tolist()[:k]
+        doc_indices = sorted_result.tolist()[:k]
+        return doc_score, doc_indices
+
+    def get_relevant_doc_bulk(self, queries: List, k: Optional[int] = 1) -> Tuple[List, List]:
+        with timer("transform"):
+            tokenized_queries = [self.tokenize_fn(query) for query in queries]
+
+        with timer("exhaustive search"):
+            result = np.array([self.bm25.get_scores(tokenized_query) for tokenized_query in tqdm(tokenized_queries)])
+
+        doc_scores = []
+        doc_indices = []
+        for i in range(result.shape[0]):
+            sorted_result = np.argsort(result[i, :])[::-1]
+            doc_scores.append(result[i, :][sorted_result].tolist()[:k])
+            doc_indices.append(sorted_result.tolist()[:k])
+        return doc_scores, doc_indices
+
+
 def main(args):
     # Test sparse
     org_dataset = load_from_disk(args.dataset_name)
@@ -369,11 +473,20 @@ def main(args):
         use_fast=False,
     )
 
-    retriever = SparseRetrieval(
-        tokenize_fn=tokenizer.tokenize,
-        data_path=args.data_path,
-        context_path=args.context_path,
-    )
+    # BM25 사용
+    if args.bm25:
+        retriever = BM25(
+            tokenize_fn=tokenizer.tokenize,
+            data_path=args.data_path,
+            context_path=args.context_path,
+        )
+    # TF-IDF 사용
+    else:
+        retriever = SparseRetrieval(
+            tokenize_fn=tokenizer.tokenize,
+            data_path=args.data_path,
+            context_path=args.context_path,
+        )
     retriever.get_sparse_embedding()
 
     query = "대통령을 포함한 미국의 행정부 견제권을 갖는 국가 기관은?"
@@ -420,6 +533,7 @@ if __name__ == "__main__":
     parser.add_argument("--context_path", default="wikipedia_documents.json", type=str, help="")
     parser.add_argument("--use_faiss", default=False, type=bool, help="")
     parser.add_argument("--topk", default=40, type=int, help="retrieve 할 문서 개수(topk) 설정")
+    parser.add_argument("--bm25", default=True, type=bool, help="BM25를 사용할 경우 True, TF-IDF를 사용할 경우 False")
 
     args = parser.parse_args()
     print(args)

--- a/baseline/retrieval.py
+++ b/baseline/retrieval.py
@@ -7,11 +7,11 @@ import pickle
 import time
 from contextlib import contextmanager
 
-from rank_bm25 import BM25Okapi
 import faiss
 import numpy as np
 import pandas as pd
 from datasets import Dataset, concatenate_datasets, load_from_disk
+from rank_bm25 import BM25Okapi
 from sklearn.feature_extraction.text import TfidfVectorizer
 from tqdm.auto import tqdm
 from transformers import AutoTokenizer
@@ -353,7 +353,12 @@ class SparseRetrieval:
 
 
 class BM25:
-    def __init__(self, tokenize_fn, data_path: Optional[str] = "../data", context_path: Optional[str] = "wikipedia_documents.json"):
+    def __init__(
+        self,
+        tokenize_fn,
+        data_path: Optional[str] = "../data",
+        context_path: Optional[str] = "wikipedia_documents.json",
+    ):
         self.data_path = data_path
         with open(os.path.join(data_path, context_path), "r", encoding="utf-8") as f:
             wiki = json.load(f)
@@ -509,7 +514,9 @@ def main(args):
             df = retriever.retrieve(full_ds, topk=args.topk)
 
             # original_context : ground_truth context / context : retrieve한 context
-            df["correct"] = [original_context in context for original_context, context in zip(df["original_context"], df["context"])]
+            df["correct"] = [
+                original_context in context for original_context, context in zip(df["original_context"], df["context"])
+            ]
             print(
                 "correct retrieval result by exhaustive search",
                 df["correct"].sum() / len(df),

--- a/baseline/retrieval.py
+++ b/baseline/retrieval.py
@@ -27,7 +27,7 @@ class SparseRetrieval:
         tokenize_fn,
         data_path: Optional[str] = "../data/",
         context_path: Optional[str] = "wikipedia_documents.json",
-    ) -> NoReturn:
+    ):
 
         """
         Arguments:
@@ -353,18 +353,19 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="")
-    parser.add_argument("--dataset_name", metavar="./data/train_dataset", type=str, help="")
+    parser.add_argument("--dataset_name", default="../data/train_dataset", type=str, help="")
     parser.add_argument(
         "--model_name_or_path",
-        metavar="bert-base-multilingual-cased",
+        default="klue/roberta-large",
         type=str,
         help="",
     )
-    parser.add_argument("--data_path", metavar="./data", type=str, help="")
-    parser.add_argument("--context_path", metavar="wikipedia_documents", type=str, help="")
-    parser.add_argument("--use_faiss", metavar=False, type=bool, help="")
+    parser.add_argument("--data_path", default="../data", type=str, help="")
+    parser.add_argument("--context_path", default="wikipedia_documents.json", type=str, help="")
+    parser.add_argument("--use_faiss", default=False, type=bool, help="")
 
     args = parser.parse_args()
+    print(args)
 
     # Test sparse
     org_dataset = load_from_disk(args.dataset_name)

--- a/baseline/retrieval.py
+++ b/baseline/retrieval.py
@@ -185,7 +185,7 @@ class SparseRetrieval:
                     "question": example["question"],
                     "id": example["id"],
                     # Retrieve한 Passage의 id, context를 반환합니다.
-                    "context_id": doc_indices[idx],
+                    # "context_id": doc_indices[idx],
                     "context": " ".join([self.contexts[pid] for pid in doc_indices[idx]]),
                 }
                 if "context" in example.keys() and "answers" in example.keys():
@@ -415,7 +415,7 @@ class BM25:
                     "question": example["question"],
                     "id": example["id"],
                     # Retrieve한 Passage의 id, context를 반환합니다.
-                    "context_id": doc_indices[idx],
+                    # "context_id": doc_indices[idx],
                     "context": " ".join([self.contexts[pid] for pid in doc_indices[idx]]),
                 }
                 if "context" in example.keys() and "answers" in example.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn==1.2.0
 torch==1.13.0
 transformers==4.25.1
 wandb==0.13.7
+rank-bm25==0.2.2


### PR DESCRIPTION
## ⚠️ Problem Statement

<!-- 이 작업을 수행하여 해결하려는 문제 -->

1. #15 에서 제기한대로, **retriever의 성능 비교를 위한 수치화 평가 방법**이 필요
- baseline 코드 내에 retriever의 성능을 수치화하여 평가하는 코드가 아래와 같이 있지만, **topk를 늘렸을 때 제대로 평가 점수 산출이 되지 않아 수정 필요**

2. #14 에서 제기한대로, 기존 TF-IDF retriever를 개선한 **BM25 sparse embedding 적용**하여 **성능 향상 도모**


## 🔧 Methodology

<!-- 해결하고자 하는 방안 -->
1. **retriever의 성능 비교를 위한 수치화 평가 방법** 수정
- [관련 commit](https://github.com/boostcampaitech4lv23nlp2/level2_mrc_nlp-level2-nlp-10/pull/16/commits/88e26ee56f496bdb078a784f8389217d1c3dc0cf)

```python3
# 수정 전
df = retriever.retrieve(full_ds)
df["correct"] = df["original_context"] == df["context"]
print(
    "correct retrieval result by exhaustive search",
    df["correct"].sum() / len(df),
)

# 수정 후
df = retriever.retrieve(full_ds, topk=args.topk)
# original_context : ground_truth context / context : retrieve한 context
df["correct"] = [
    original_context in context for original_context, context in zip(df["original_context"], df["context"])
]
print(
    "correct retrieval result by exhaustive search",
    df["correct"].sum() / len(df),
)
```

2. rank-bm25 모듈의 BM25Okapi 활용하여 **BM25 sparse embedding 구현**
- [관련 commit](https://github.com/boostcampaitech4lv23nlp2/level2_mrc_nlp-level2-nlp-10/pull/16/commits/6c39032b5c31947cd40552d35a1db4f64cac7283)


## 🚧 TODO LIST

- [x] retriever의 성능 비교를 위한 수치화 평가 방법 수정
- [x] BM25 적용

## ⚗️ Results

<!-- 실험(적용) 과정과 결과 -->
1. #15 에 사진 첨부
2. #14 에 사진 첨부

## 🔀 Conclusion

<!-- 실험에 따른 결론과 대안 -->
- https://github.com/boostcampaitech4lv23nlp2/level2_mrc_nlp-level2-nlp-10/issues/15#issuecomment-1378956375

- https://github.com/boostcampaitech4lv23nlp2/level2_mrc_nlp-level2-nlp-10/issues/14#issuecomment-1378980922

## 📄 Related Issue

<!-- 관련 PR 링크 작성 -->
close #14
close #15 
